### PR TITLE
office: refresh worker briefs (12 chats) + introduce scratch/reserve roles

### DIFF
--- a/OFFICE.md
+++ b/OFFICE.md
@@ -1,0 +1,291 @@
+# OFFICE.md — Multi-Worker Coordination Spec for QuarterCharts
+
+This is the design spec for the 9-worker parallel Claude Code setup. Read this once, refer back when conflicts surface, never paste into prompts (it's for humans + the orchestrator, not workers).
+
+---
+
+## Why this exists
+
+Sebastián runs 9 parallel Claude Code chats (pinned `1. *`) across separate git worktrees of `miteproyects`. Each chat is an independent Claude process with its own context window. They share one filesystem and one git repo, so without coordination they'd:
+
+1. Edit the same file simultaneously and overwrite each other.
+2. Duplicate work (e.g., Currency and US Charts originally had the same brief).
+3. Hold stale information about what peers have already done.
+4. Burn tokens narrating intent in human English.
+
+This spec defines a **file-based coordination layer** — locks, events, inbox, lookup — that runs **outside the LLM** via Claude Code hooks. Coordination cost: zero LLM tokens. Workers only spend tokens reading peer state when they actually need to make a decision.
+
+> **Why not Claude Code Agent Teams?** Anthropic's `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` assumes one lead session spawns teammates inside its own project. We have 9 independent leads in 9 worktrees — wrong topology. The flag is enabled in settings for future use; the protocol below is what actually runs today.
+
+---
+
+## Architecture at a glance
+
+```
+9 Claude Code processes (one per worktree)
+        │
+        │  hooks fire on every tool call / turn boundary
+        ▼
+   ┌─────────────────────────────────────────┐
+   │   ~/.qc-office/  (shared FS, no repo)   │
+   │                                         │
+   │   agents.json     ← registry            │
+   │   inbox/<name>.md ← peer messages       │
+   │   locks/<file>    ← file locks          │
+   │   events/         ← append-only log     │
+   └─────────────────────────────────────────┘
+        ▲
+        │  on demand: workers read inbox / events
+        │  on demand: dashboard tails events.jsonl
+        ▼
+   office.quartercharts.com  (Phase 3)
+   ─ live floor plan
+   ─ chat-room feed (decoded events)
+   ─ ttyd-per-worker terminals (iframed)
+```
+
+### Why `~/.qc-office/` and not the repo?
+
+- Survives `git clean -fdx`, branch switches, worktree resets.
+- Not tracked by git → no PR noise from runtime state.
+- All 9 worktrees can read/write because it's at user-home, not project-relative.
+- Easy to back up / blow away in one place.
+
+---
+
+## The 9 workers (canonical names)
+
+Use the **canonical names** below in events, not chat labels or worktree slugs. The mapping lives in `~/.qc-office/agents.json`.
+
+| Canonical name     | Chat label          | Worktree slug             | Owns                     |
+| ------------------ | ------------------- | ------------------------- | ------------------------ |
+| `office`           | 1. Office           | eloquent-lewin-7c8efe     | orchestration, this spec |
+| `currency`         | 1. Currency         | lucid-khayyam-9b0a8c      | api.qc.com (FastAPI)     |
+| `us-charts`        | 1. US Charts        | kind-haslett-2451e3       | us.qc.com (Next.js)      |
+| `super-companias`  | 1. Super Compañías  | crazy-kilby-d4c673        | tfcsmart.com extraction  |
+| `dns`              | 1. DNS              | stoic-ellis-63f6bc        | DNS migration            |
+| `globe`            | 1. Globe            | silly-benz-aff74f         | world.qc.com globe       |
+| `business-model`   | 1. Business model   | gallant-swartz-5ac5a7     | docs/business-model      |
+| `logo`             | 1. Logo             | youthful-bouman-460ec2    | header logos             |
+| `searching-tool`   | 1. Searching Tool   | unruffled-raman-d25796    | search infra             |
+
+Per-worker scope, file ownership, and bootstrap notes: see `WORKERS/<name>.md`.
+
+---
+
+## The agent language (10-event TOON-style vocabulary)
+
+Every coordination message is one line in `~/.qc-office/events/events.jsonl`. Format:
+
+```
+<ISO-8601-utc-Z> <code> key1=value1 key2="value with spaces" key3=value3
+```
+
+| Code | Meaning              | Required fields                       | Typical token cost |
+| ---- | -------------------- | ------------------------------------- | ------------------ |
+| `L`  | Lock acquired        | `file`, `from`, `ttl` (seconds)       | ~8 tokens          |
+| `U`  | Lock released        | `file`, `from`                        | ~6 tokens          |
+| `S`  | Status / heartbeat   | `from`, `state` (idle/typing/waiting) | ~6 tokens          |
+| `T`  | Task started         | `from`, `task_id`, `scope`            | ~10 tokens         |
+| `D`  | Task done            | `from`, `task_id`, `summary` (≤30tok) | ~30 tokens         |
+| `Q`  | Question to peer     | `from`, `to`, `q_id`, `topic`         | ~12 tokens         |
+| `A`  | Answer to peer       | `to`, `q_id`, `data`                  | varies             |
+| `R`  | Request room cleared | `from`, `file`, `reason`              | ~12 tokens         |
+| `Y`  | Yield room           | `from`, `file`                        | ~6 tokens          |
+| `H`  | Halt / escalate      | `from`, `reason`                      | ~12 tokens         |
+
+**Rules:**
+- ASCII only. No emoji, no Unicode quotes, no English narration.
+- `summary` and `data` fields use double-quotes with escaped internal quotes.
+- An agent reading 50 events ≈ 400 tokens. The same exchange in English ≈ 10K tokens.
+
+### Example: globe needs to refactor a shared file
+
+```
+2026-04-28T07:15:00Z R from=globe file=world-app/lib/geo.ts reason="adding country borders"
+2026-04-28T07:15:01Z Y from=us-charts file=world-app/lib/geo.ts
+2026-04-28T07:15:02Z Y from=logo file=world-app/lib/geo.ts
+2026-04-28T07:15:03Z L from=globe file=world-app/lib/geo.ts ttl=600
+2026-04-28T07:18:42Z U from=globe file=world-app/lib/geo.ts
+2026-04-28T07:18:43Z D from=globe task_id=globe-borders summary="added countries layer to deck.gl, 320 lines"
+```
+
+Six events, ~70 tokens total. Fully resolved a multi-agent file conflict.
+
+---
+
+## File locking
+
+### Lockfile path
+
+`~/.qc-office/locks/<sanitized-relative-path>.lock`
+
+Sanitization: replace `/` with `__`. Replace `.` in the filename with `__DOT__` only if there are special-char concerns (most paths are safe with just `/` swap).
+
+Examples:
+- `app.py` → `~/.qc-office/locks/app.py.lock`
+- `docs/foo.md` → `~/.qc-office/locks/docs__foo.md.lock`
+- `world-app/components/Globe.tsx` → `~/.qc-office/locks/world-app__components__Globe.tsx.lock`
+
+### Lockfile body
+
+```
+owner: globe
+acquired: 2026-04-28T07:15:32Z
+ttl: 600
+worktree: silly-benz-aff74f
+pid: 12345
+```
+
+### Lifecycle (REVISED 2026-04-28-T1 — locks held for whole turn, not just one tool call)
+
+1. **Acquire** (in `pretooluse-lockcheck.py`, fires before each Edit/Write/MultiEdit/NotebookEdit):
+   - If lockfile doesn't exist → atomic `O_CREAT|O_EXCL` create with our identity → exit 0 (proceed).
+   - If lockfile exists and `now - acquired > ttl` → stale, take it over → exit 0.
+   - If lockfile exists and owner == us → refresh `acquired` (extends TTL) → exit 0.
+   - Else → owned by another agent and fresh → **exit 2** with reason. Tool call is blocked. Agent's LLM gets the reason as feedback.
+
+2. **Note** (in `posttooluse-event.py`, fires after each Edit/Write/MultiEdit/NotebookEdit):
+   - Logs a `T` event recording what was just touched.
+   - **Does NOT release the lock** — the lock is held for the rest of the turn so multi-edit refactors don't get clobbered between Edit calls.
+
+3. **Release** (in `stop-event.py`, fires when the turn ends):
+   - Iterates `~/.qc-office/locks/`, finds every lock with `owner == us`, deletes them.
+   - Emits one `U` event per released lock.
+   - Then logs `S=idle` and `D=turn_end`.
+
+4. **Fence** (max-locks rule):
+   - In acquire, count locks owned by us. If ≥ 5 → **exit 2** with "too many locks held". Forces small, focused turns.
+
+### Why the old design (release on PostToolUse) was wrong
+
+In the original Phase 1B design, the lock was acquired in PreToolUse and released in PostToolUse — so a worker only held the lock for the ~50ms duration of a single Edit call. A peer could swoop in and edit the same file 51ms later, which is the exact thing locks are meant to prevent. The 2026-04-28 conflict-test exposed this immediately: logo and globe wrote to the same file with no overlap because both released their locks before the other tried to acquire.
+
+The fix (above): hold the lock until the turn ends. Mental model: "this worker is working on this file" — same as how a human dev would think about it.
+
+### Race-condition handling
+
+The hooks use `os.O_CREAT | os.O_EXCL` on the lockfile path. Two agents racing PreToolUse on the same file → only one syscall succeeds, the loser sees `FileExistsError` and exits 2 with "claimed in a race". Verified end-to-end with two parallel hook invocations 2026-04-28.
+
+---
+
+## The awareness loop (zero-token)
+
+Agents do **not** poll the event log on every turn. That would waste tokens. Instead:
+
+1. **`SessionStart` hook** (when a worker chat opens):
+   - Append `S=online` event.
+   - Tail last 30 events from `events.jsonl`, filter to entries from peers (not us), inject as a system reminder.
+
+2. **`UserPromptSubmit` hook** (every user turn):
+   - Check `~/.qc-office/inbox/<me>.md`. If unread peer messages, prepend their compact form to the user's prompt.
+   - Append `S=working` event.
+
+3. **`PreToolUse` hook on Edit | Write | NotebookEdit**:
+   - Run `pretooluse-lockcheck.sh`. Block (exit 2) if peer holds the lock.
+
+4. **`PostToolUse` hook on Edit | Write | NotebookEdit**:
+   - Release our lock. Append `U` + `T` events.
+
+5. **`Stop` hook** (turn ends):
+   - Append `D` event with a 30-token summary derived from the LLM's last assistant message (truncated).
+
+The agent never has to think about coordination — it just does its work, and the hooks make sure peers know.
+
+---
+
+## The inbox
+
+`~/.qc-office/inbox/<name>.md` is a plain markdown file, append-only by hooks, trimmed to last 20 entries.
+
+### When does the inbox get written?
+
+- **Direct messages**: when peer sends `Q` or `A` event with `to=<me>`, the receiving agent's `posttooluse-event.sh` (running on the *sender's* side) writes the message to `inbox/<me>.md`. (Cross-process write — works because filesystem is shared.)
+- **Room-clearing**: when peer sends `R` with `file=<one-of-my-locks>`, my next hook fire writes a high-priority entry to my inbox.
+- **Halts**: when any agent emits `H`, **all 9** inboxes get a copy + the office worker gets a flagged escalation.
+
+### When does an agent read it?
+
+- Automatically: `UserPromptSubmit` hook prepends unread entries to the user's prompt (if any).
+- Manually: agent calls `Read` on `~/.qc-office/inbox/<me>.md` when prompted by `syncqc` or similar.
+
+### Read marker
+
+A separator line `<!-- READ: <ISO-timestamp> -->` is inserted by the agent when it reads. Hook prepends only entries below the most recent read marker.
+
+---
+
+## Conflict-resolution rules
+
+1. **Stay in your lane.** Each worker has `owns_files` in `agents.json`. Edits inside your lane: no announcement needed (still acquire lock). Edits outside: emit `R`, wait for `Y` from current owner before locking.
+2. **5-lock max.** No agent holds more than 5 active locks. Forces small commits.
+3. **TTL is sacred.** Default 600s. If your task takes longer, refresh the lock by re-running the same hook (any tool call on the file refreshes). If you go silent for 10+ minutes with the lock held, peers will rip it.
+4. **Office breaks ties.** If two agents both `R` for the same file, `office` arbitrates by emitting `H` to the loser. Loser yields and re-queues.
+5. **Halt is for humans.** `H` events surface in Sebastián's dashboard with audio. Use sparingly.
+
+---
+
+
+<!-- ROLES-LEGEND-v1 -->
+## Roles in `agents.json`
+
+The protocol distinguishes four roles. Hooks branch on these:
+
+| Role | Hooks behavior | Lock cap | Use case |
+| --- | --- | --- | --- |
+| `orchestrator` | Full participation. Lock + event spam allowed. | 25 | The single `office` chat. |
+| `worker` | Full participation. Standard. | 5 | All real product workers (us-charts, globe, currency, etc.). |
+| `scratch` | **No-op.** No locks, no event log entries, no inbox surfacing. | n/a | Sebastián's personal pads (`notes`). |
+| `reserve` | **No-op.** Same as scratch. | n/a | Empty hot-spares (`open-slot-1`). |
+
+Non-participating roles (`scratch`, `reserve`) are still discovered and shown on the dashboard, but they don't block other workers and aren't blocked by them.
+
+## Roadmap
+
+| Phase | Scope                                                                                  | Status |
+| ----- | -------------------------------------------------------------------------------------- | ------ |
+| 0     | Rotate the office password (Sebastián chooses, stores in Apple Passwords).             | ⏳     |
+| 1A    | `~/.qc-office/` bootstrap, `agents.json`, this spec, per-worker `WORKERS/<name>.md`.   | ✅     |
+| 1B    | Hook scripts in `.claude/hooks/`. Inert until Phase 1C wires them in.                  | ⏳     |
+| 1C    | `.claude/settings.json` enables Agent Teams flag + registers hooks.                    | ⏳     |
+| 1D    | Smoke test: 3 workers each lock a file simultaneously; verify queueing + events.       | ⏳     |
+| 2     | Replace file-based events with NATS JetStream on Railway. Hooks publish to NATS too.   | ⏳     |
+| 3     | `office.quartercharts.com` Next.js dashboard on Vercel. Auth-gated. WebSocket bridge.  | ⏳     |
+| 4     | `ttyd` per worker on Mac, tunneled via Cloudflare, iframed in dashboard.               | ⏳     |
+| 5     | Cool visual layer (isometric office or force-graph). Replaces grid placeholder.        | ⏳     |
+| 6     | Optional: room-clearing UX, audio cues, dashboard-driven worker spawn/kill.            | ⏳     |
+
+---
+
+## Critical caveats
+
+- **Hooks must finish in <200ms** or they degrade Claude Code responsiveness. All hook scripts use only filesystem ops — no network calls until Phase 2.
+- **The `~/.qc-office/` directory is per-machine, not per-user-account.** If Sebastián logs in on a second Mac, that Mac has its own coordination layer. Phase 2 (NATS) fixes this.
+- **Worktrees share a git history.** Two agents pushing different commits to different branches is fine; two agents committing to the same branch will conflict at push time. The lock layer prevents same-file edits but doesn't prevent same-branch commits — keep `branch ≠ branch` between agents (already true today).
+- **The `office` worker (this chat) is special.** It owns this spec, the registry, and the dashboard. It does NOT edit app code unless explicitly assigned. Other workers route questions here via `Q to=office`.
+
+---
+
+## How to use this as a non-orchestrator worker
+
+You're one of the 8 non-`office` workers? Three things:
+
+1. **Read your `WORKERS/<your-name>.md` file.** That's your scope and file ownership.
+2. **Don't read this whole spec.** The hooks handle coordination. You'll get nudged when peers need something.
+3. **Speak in events when prompted.** If asked to broadcast intent, emit one of the 10 codes — never English narration. The orchestrator decodes for Sebastián.
+
+---
+
+## How to use this as the orchestrator (`office`)
+
+That's me. My job:
+- Maintain `agents.json` (this is the source of truth — chat names can drift).
+- Watch `events/events.jsonl` for `H` escalations.
+- Arbitrate `R`/`Y` ties.
+- Curate `WORKERS/*.md` briefs as scopes evolve.
+- Build & maintain the dashboard (Phase 3+).
+- Don't touch app code without an explicit assignment from Sebastián.
+
+---
+
+*Last updated: 2026-04-28 by office worker (eloquent-lewin-7c8efe).*

--- a/OFFICE.md
+++ b/OFFICE.md
@@ -1,12 +1,14 @@
 # OFFICE.md — Multi-Worker Coordination Spec for QuarterCharts
 
-This is the design spec for the 9-worker parallel Claude Code setup. Read this once, refer back when conflicts surface, never paste into prompts (it's for humans + the orchestrator, not workers).
+This is the design spec for the parallel-Claude-Code setup. Read this once, refer back when conflicts surface, never paste into prompts (it's for humans + the orchestrator, not workers).
+
+> **Live roster**: see `~/.qc-office/agents.json` (auto-discovered every ~10s by `~/.qc-office/hooks/discover-agents.py`). The chat count churns as Sebastián spins up new workers and archives old ones — the `agents.json` registry is the source of truth, not any list in this doc.
 
 ---
 
 ## Why this exists
 
-Sebastián runs 9 parallel Claude Code chats (pinned `1. *`) across separate git worktrees of `miteproyects`. Each chat is an independent Claude process with its own context window. They share one filesystem and one git repo, so without coordination they'd:
+Sebastián runs ~10–15 parallel Claude Code chats (pinned `QC.*`, formerly `1.*`) across separate git worktrees of `miteproyects`. Each chat is an independent Claude process with its own context window. They share one filesystem and one git repo, so without coordination they'd:
 
 1. Edit the same file simultaneously and overwrite each other.
 2. Duplicate work (e.g., Currency and US Charts originally had the same brief).
@@ -15,14 +17,14 @@ Sebastián runs 9 parallel Claude Code chats (pinned `1. *`) across separate git
 
 This spec defines a **file-based coordination layer** — locks, events, inbox, lookup — that runs **outside the LLM** via Claude Code hooks. Coordination cost: zero LLM tokens. Workers only spend tokens reading peer state when they actually need to make a decision.
 
-> **Why not Claude Code Agent Teams?** Anthropic's `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` assumes one lead session spawns teammates inside its own project. We have 9 independent leads in 9 worktrees — wrong topology. The flag is enabled in settings for future use; the protocol below is what actually runs today.
+> **Why not Claude Code Agent Teams?** Anthropic's `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` assumes one lead session spawns teammates inside its own project. We have many independent leads across many worktrees — wrong topology. The flag is enabled in settings for future use; the protocol below is what actually runs today.
 
 ---
 
 ## Architecture at a glance
 
 ```
-9 Claude Code processes (one per worktree)
+N Claude Code processes (one per worktree)
         │
         │  hooks fire on every tool call / turn boundary
         ▼
@@ -36,38 +38,48 @@ This spec defines a **file-based coordination layer** — locks, events, inbox, 
    └─────────────────────────────────────────┘
         ▲
         │  on demand: workers read inbox / events
-        │  on demand: dashboard tails events.jsonl
+        │  daemon tails events.jsonl + serves SSE
         ▼
-   office.quartercharts.com  (Phase 3)
-   ─ live floor plan
-   ─ chat-room feed (decoded events)
-   ─ ttyd-per-worker terminals (iframed)
+   office.quartercharts.com  (Cloudflare-Access-gated)
+   ─ isometric office floor (live agent state)
+   ─ chat-room feed (decoded events, real-time)
+   ─ ttyd-per-worker terminals (iframed)  [Phase 6]
 ```
 
 ### Why `~/.qc-office/` and not the repo?
 
 - Survives `git clean -fdx`, branch switches, worktree resets.
 - Not tracked by git → no PR noise from runtime state.
-- All 9 worktrees can read/write because it's at user-home, not project-relative.
+- All worktrees can read/write because it's at user-home, not project-relative.
 - Easy to back up / blow away in one place.
 
 ---
 
-## The 9 workers (canonical names)
+## Workers — canonical names
 
-Use the **canonical names** below in events, not chat labels or worktree slugs. The mapping lives in `~/.qc-office/agents.json`.
+Use the **canonical name** in events, not the chat label or worktree slug. The live roster lives in `~/.qc-office/agents.json`, auto-discovered from Claude desktop's session metadata. The shape of each entry:
 
-| Canonical name     | Chat label          | Worktree slug             | Owns                     |
-| ------------------ | ------------------- | ------------------------- | ------------------------ |
-| `office`           | 1. Office           | eloquent-lewin-7c8efe     | orchestration, this spec |
-| `currency`         | 1. Currency         | lucid-khayyam-9b0a8c      | api.qc.com (FastAPI)     |
-| `us-charts`        | 1. US Charts        | kind-haslett-2451e3       | us.qc.com (Next.js)      |
-| `super-companias`  | 1. Super Compañías  | crazy-kilby-d4c673        | tfcsmart.com extraction  |
-| `dns`              | 1. DNS              | stoic-ellis-63f6bc        | DNS migration            |
-| `globe`            | 1. Globe            | silly-benz-aff74f         | world.qc.com globe       |
-| `business-model`   | 1. Business model   | gallant-swartz-5ac5a7     | docs/business-model      |
-| `logo`             | 1. Logo             | youthful-bouman-460ec2    | header logos             |
-| `searching-tool`   | 1. Searching Tool   | unruffled-raman-d25796    | search infra             |
+```jsonc
+{
+  "<canonical-name>": {
+    "role": "orchestrator" | "worker" | "scratch" | "reserve",
+    "worktree": "/abs/path/to/worktree",
+    "worktree_exists": true,
+    "is_archived": false,
+    "branch": "claude/...",
+    "chat_label": "QC. <Display Name>",
+    "scope": "one-line scope description",
+    "owns_files": ["glob/**", "..."],
+    "_cli_session_id": "<uuid>",
+    "_session_metadata": "/path/to/Claude/local_<uuid>.json"
+  }
+}
+```
+
+Canonical names are derived from chat labels by stripping the `QC.` (or legacy `1.`) prefix and slug-casing the rest:
+- `QC. Office` → `office`
+- `QC. US Charts` → `us-charts`
+- `QC. Super Compañías` → `super-companias`
 
 Per-worker scope, file ownership, and bootstrap notes: see `WORKERS/<name>.md`.
 

--- a/WORKERS/README.md
+++ b/WORKERS/README.md
@@ -1,0 +1,17 @@
+# WORKERS/ — per-worker briefs
+
+One MD per active worker, named with the canonical name from `~/.qc-office/agents.json`.
+
+Each brief is the **single source of truth** for that worker's:
+- Scope (what they're allowed to touch)
+- Owned files (lock-priority lanes)
+- Active task list
+- Open questions for `office` to route
+
+When a worker reads `syncqc`, they read `CLAUDE.md` + `OFFICE.md` (read-once) + their own `WORKERS/<me>.md`. They do **not** read other workers' briefs unless arbitrating.
+
+The orchestrator (`office`) is the only writer of these files. Workers write back via:
+- **Q events** to ask `office` to update their brief.
+- **D events** with `task_id` referencing entries in their own `## Tasks` section.
+
+See `OFFICE.md` (root of repo) for the full spec.

--- a/WORKERS/business-model.md
+++ b/WORKERS/business-model.md
@@ -1,0 +1,40 @@
+# business-model — Multi-country biz model & docs
+
+**Worktree**: `.claude/worktrees/gallant-swartz-5ac5a7`
+**Chat label**: `QC. Business model`
+
+## Role
+
+Define the business model for the multi-country expansion of QuarterCharts. **Output is documents, not code.** Owns the canonical product model: `world.qc.com` (landing) → per-country pages (`us.qc.com`, `ec.qc.com`, `mx.qc.com`, …) → ticker pages. Defines paywall tiers per market, the acquirer narrative for BLIP COMPANY LLC, and pricing strategy.
+
+## Owns
+
+- `docs/business-model/**`
+- `docs/pricing/**`
+- `docs/market-research/**`
+- `docs/acquirer-narrative/**`
+
+## Out of scope (do NOT touch)
+
+- All application code (read-only).
+- DNS / infra (`platform` worker owns).
+- Legal copy itself (`legal` worker owns; coordinate via `Q to=legal` for compliance touchpoints).
+
+## Cross-worker coordination
+
+- `Q to=globe` — which countries to show as "live" vs "coming soon" on the world map.
+- `Q to=super-companias` — EC-specific data-source strategy.
+- `Q to=legal` — compliance constraints for new markets.
+
+## Tasks (suggested initial)
+
+- [ ] T1: Document the page hierarchy: world.qc → country.qc → ticker page → `docs/business-model/site-map.md`.
+- [ ] T2: Per-country pricing strategy, US + EC + MX first → `docs/pricing/per-country.md`.
+- [ ] T3: Acquirer narrative one-pager — why QC is acquirable, who the natural buyers are, what's needed to be ready (revenue, TAM, differentiation) → `docs/acquirer-narrative/v1.md`.
+- [ ] T4: Define legal entity flow: BLIP COMPANY LLC owns all domains/payments per memory note → `docs/business-model/legal-structure.md`.
+
+## Open questions
+
+- Will country pages share auth/account, or per-country accounts?
+- Stripe — one Stripe account per country (for tax compliance) or one global with VAT/IGV/IVA logic?
+- When does QC start charging (free-tier sunset date)?

--- a/WORKERS/currency.md
+++ b/WORKERS/currency.md
@@ -1,0 +1,50 @@
+# currency — FX / currency conversion layer
+
+**Worktree**: `.claude/worktrees/lucid-khayyam-9b0a8c`
+**Chat label**: `QC. Currency`
+
+## Role
+
+The financial-currency-conversion layer used across QC. Converts all financial values between USD and the local currency of whichever country the user is viewing. Provides a single shared library + (optional) microservice that every other front-end / back-end worker calls.
+
+**Note**: this scope reflects the 2026-04-28 reassignment. The earlier "Phase 1 FastAPI backend" scope moved to the new `platform` worker. Currency is now data, not infra.
+
+## Owns
+
+- `currency/**` (the conversion library)
+- `lib/fx/**` (alternative path, depending on directory layout chosen)
+- `currency/sources/**` (FX rate provider adapters: ECB, OpenExchangeRates, fallbacks)
+- `currency/cache/**` (rate caching policy)
+- Tests for the above
+
+## Out of scope (do NOT touch)
+
+- Streamlit / FastAPI / Vercel deploy plumbing → `platform` worker owns.
+- Country-specific data extraction (e.g. Ecuadorian financials) → `super-companias` for EC, future workers for other countries.
+- UI presentation of FX-converted numbers → owned by whichever frontend (`us-charts`, `globe`, etc.) consumes the library.
+
+## Cross-worker coordination
+
+- `Q to=super-companias` — what currency are EC raw values in (USD-denominated since Ecuador is dollarized, but verify)?
+- `Q to=us-charts` — how to surface the "values shown in $X" indicator in the UI.
+- `Q to=business-model` — pricing tier policy for currency-aware features.
+
+## API surface (proposed, for review)
+
+```
+convert(amount: number, from: ISO4217, to: ISO4217, asOf?: date): number
+historicalRate(from: ISO4217, to: ISO4217, asOf: date): number
+preferredCurrencyForUser(userCountryCode): ISO4217
+```
+
+## Tasks (suggested initial)
+
+- [ ] T1: Pick the FX rate source(s). ECB (free, daily) + OpenExchangeRates (free tier, hourly) is a reasonable starting combo. Document in `docs/currency/sources.md`.
+- [ ] T2: Build the conversion library with rate caching + fallbacks.
+- [ ] T3: Build a tiny FX rate-fetcher daemon or scheduled job (coordinate with `platform`).
+- [ ] T4: Integrate into us-charts via `Q` exchange.
+
+## Open questions
+
+- Where does the library live: `miteproyects` repo, separate repo, or shared via npm/PyPI? (Defer to office for cross-cutting infra decisions.)
+- Should it be a Python library, a TS library, or both? (Different consumers want different runtimes.)

--- a/WORKERS/globe.md
+++ b/WORKERS/globe.md
@@ -1,0 +1,44 @@
+# globe — world.quartercharts.com 3D globe widget
+
+**Worktree**: `.claude/worktrees/silly-benz-aff74f`
+**Chat label**: `QC. Globe`
+
+## Role
+
+Own the entire 3D-globe widget on `world.quartercharts.com`. This is the multi-country landing experience. Each country dot click → that country's `<cc>.quartercharts.com` page (US lives, others coming).
+
+Replaces the old narrow "fix 3 specific bugs" scope with full ownership of the widget.
+
+## Owns
+
+- `world-app/components/Globe*` (Globe.tsx, GlobeControls.tsx, GlobeOverlay.tsx, etc.)
+- `world-app/lib/geo*` (projection helpers, country lookup, geo-data loading)
+- `world-app/data/countries.geo.json` (or wherever Natural Earth / TopoJSON country borders live)
+- `world-app/hooks/useGlobe*`
+- Tests for the above
+
+## Out of scope (do NOT touch)
+
+- Header / nav / logos (us-charts owns headers; logo work is folded back into us-charts).
+- Search box on the world page → `searching-tool` was retired; if a successor appears, coordinate.
+- Backend / API plumbing → `platform` owns.
+- Per-country financial data → `super-companias` (EC) and future country workers.
+
+## Open bugs (carried forward from earlier scope)
+
+- [ ] T1: Country borders — confirm they render. Likely needs Natural Earth GeoJSON layer wired to deck.gl / globe.gl.
+- [ ] T2: Drag/zoom interactions — verify the controller prop is set + globe-gl is the chosen library.
+- [ ] T3: USA dot click → `https://us.quartercharts.com` (or relative redirect if same Vercel project).
+- [ ] T4: Coordinate with `dns` (now folded into `platform`) on the redirect target — `us.qc.com` not `usa.qc.com` per memory.
+- [ ] T5: Coordinate with `business-model` on which countries show as "live" vs "coming soon".
+
+## Cross-worker coordination
+
+- `Q to=business-model` — country activation order.
+- `Q to=platform` — DNS for new country subdomains.
+- `Q to=us-charts` — visual handoff when a user clicks the USA dot.
+
+## Open questions
+
+- Which library is the actual current choice — globe.gl, react-globe.gl, deck.gl, or three.js? (Confirm in T1.)
+- Performance: is the country GeoJSON pre-simplified or full-fidelity? (Affects drag smoothness on lower-end devices.)

--- a/WORKERS/legal.md
+++ b/WORKERS/legal.md
@@ -1,0 +1,47 @@
+# legal — Terms, privacy, compliance docs
+
+**Worktree**: (assigned by Sebastián)
+**Chat label**: `QC. Legal`
+
+## Role
+
+Owns all legal copy and compliance documentation for QuarterCharts under BLIP COMPANY LLC. Markdown only — does not write product code or modify deploy infra. Output is plain-language legal text reviewable by Sebastián and (eventually) by counsel.
+
+## Owns
+
+- `docs/legal/**` (canonical source-of-truth Markdown)
+- `us-app/(legal)/**` (Next.js-rendered legal pages: ToS, privacy, cookie policy)
+- `world-app/(legal)/**` (same, for world.qc.com)
+- `docs/compliance/**` (data retention, GDPR/CCPA notes, financial-data disclaimers)
+- Cookie banner copy (the words; the implementation lives in us-charts / globe)
+
+## Out of scope (do NOT touch)
+
+- Application logic, authentication, payment flows → other workers.
+- Cookie banner *implementation* → us-charts.
+- Tax handling logic → `business-model` + `currency` together.
+
+## Cross-worker coordination
+
+- `Q to=business-model` — multi-country compliance constraints (which markets need what).
+- `Q to=platform` — where legal pages should be served from (Vercel project, route group, etc.).
+- `Q to=office` — escalation path when legal needs to block a feature launch.
+
+## Critical disclaimer (recurring)
+
+QC shows financial data sourced from public filings (SEC EDGAR, FMP, Finnhub, yfinance, supercias.gob.ec, etc.). The site is **not** an investment advisor and does not provide financial advice. Every page that surfaces numbers must carry a "for informational purposes only" disclaimer. Coordinate the exact wording.
+
+## Tasks (suggested initial)
+
+- [ ] T1: Draft v1 ToS for `us.quartercharts.com` → `docs/legal/tos-us.md`.
+- [ ] T2: Draft v1 privacy policy (GDPR + CCPA aware even if user base is US-first) → `docs/legal/privacy.md`.
+- [ ] T3: Draft cookie banner copy + the "manage preferences" modal text.
+- [ ] T4: Draft the financial-data disclaimer used across product pages.
+- [ ] T5: Draft data-retention policy: how long event logs / user accounts / payment records are kept.
+- [ ] T6: BLIP COMPANY LLC structure note: how the LLC owns the IP, who's the registered agent, where it operates.
+
+## Open questions
+
+- Will QC have a real lawyer review before launch, or operate on best-effort drafts until revenue?
+- Stripe / payment terms — handled by Stripe's own ToS or do we need our own merchant agreement?
+- For Ecuadorian financials (`super-companias`), is there any redistribution restriction? (Public filings usually = free to redisplay, but verify.)

--- a/WORKERS/notes.md
+++ b/WORKERS/notes.md
@@ -1,0 +1,40 @@
+# notes — Sebastián's personal scratch pad
+
+**Worktree**: (assigned by Sebastián)
+**Chat label**: `QC. Notes`
+**Role**: `scratch` — NOT a regular worker.
+
+## What this is
+
+A free-form chat where Sebastián captures product / strategy / architecture ideas for future implementation. Markdown notebook lives here.
+
+## Critical rules (different from regular workers)
+
+- **Hooks no-op for this chat.** No lock enforcement, no S/D event broadcasting, no inbox surfacing. Sebastián's scratch shouldn't pollute the office event log or block other workers.
+- **No `R` / `Y` / `Q` / `A` events from this chat.** It doesn't participate in the protocol.
+- **Other workers should NOT message this chat.** Treat it as Sebastián-only. If a worker thinks it has something `notes` should know, route through `office` instead.
+- **No production code.** Output is `docs/notes/**` Markdown only.
+
+## Owns
+
+- `docs/notes/**` (idea log, future-feature sketches, half-formed thoughts)
+
+## How office handles this worker
+
+- `agents.json` carries `role: scratch`.
+- Dashboard renders the card with a quieter style (low-saturation, no pulsing).
+- Lockcheck hook short-circuits before any enforcement when the agent's role is `scratch`.
+- Discovery still surfaces it (so Sebastián sees it on the dashboard) but skips it from "active worker" counts.
+
+## When notes graduates to a real worker
+
+If a notes idea becomes a real initiative:
+1. Sebastián renames the chat from `QC. Notes` to `QC. <NewName>` (or creates a fresh chat).
+2. The original `QC. Notes` keeps existing for new ideas.
+3. The new worker gets a real `WORKERS/<new-name>.md` brief and `agents.json` entry.
+
+## Index
+
+(Sebastián fills this as ideas accumulate.)
+
+- *(empty)*

--- a/WORKERS/office.md
+++ b/WORKERS/office.md
@@ -1,0 +1,60 @@
+# office — Orchestrator
+
+**Worktree**: `.claude/worktrees/eloquent-lewin-7c8efe`
+**Branch**: `claude/eloquent-lewin-7c8efe`
+**Chat label**: `QC. Office`
+
+## Role
+
+Coordinator for the 11 other QC chats (10 active workers + 1 reserve hot-spare + 1 personal scratch). Owns the protocol (`OFFICE.md`), the dashboard at `office.quartercharts.com`, `agents.json`, the Mac daemon, the Cloudflare Tunnel, and the hook scripts.
+
+Does **not** edit application code (`app.py`, `us-app/**`, `world-app/**`, etc.) unless Sebastián assigns it explicitly. The default mode is "route, don't write."
+
+## Owns
+
+- `OFFICE.md` (the spec)
+- `WORKERS/**` (all worker briefs, including this one)
+- `.claude/hooks/**` (the in-repo hook scripts; runtime hooks live at `~/.qc-office/hooks/`)
+- `~/.qc-office/**` (filesystem coordination root, not in repo)
+- `quartercharts-com/qc-office-dashboard` (the Vercel dashboard repo)
+- Cloudflare Tunnel config: `~/.cloudflared/qc-office-daemon.yml`
+- Cloudflare Access policy on `office.quartercharts.com`
+- launchd plists: `com.quartercharts.qc-office-{daemon,tunnel,rotate}.plist`
+
+## Routing rules
+
+- **`Q to=office`** → triage. Either answer directly or forward to the right worker.
+- **`H` (escalate)** → surface to Sebastián immediately. Don't auto-resolve.
+- **`R` ties** (two agents request the same file simultaneously) → arbitrate by emitting `H` to the requester with more active locks.
+
+## Active roster (12 chats)
+
+| Canonical | Chat label | Role | Cluster |
+| --- | --- | --- | --- |
+| `office` | QC. Office | orchestrator | center |
+| `business-model` | QC. Business model | worker | research |
+| `currency` | QC. Currency | worker | backend |
+| `globe` | QC. Globe | worker | frontend |
+| `legal` | QC. Legal | worker | research |
+| `notes` | QC. Notes | **scratch** (Sebastián personal) | misc |
+| `open-slot-1` | QC. Open slot 1 | **reserve** | misc |
+| `platform` | QC. Platform | worker | backend |
+| `super-companias` | QC. Super Compañías | worker | research |
+| `us-charts` | QC. US Charts | worker | frontend |
+| `us-sankey` | QC. US Sankey | worker | frontend |
+| `vercel-skills-qc` | QC. Vercel Skills (QC) | worker | misc |
+
+`scratch` and `reserve` roles → hooks no-op (no lock enforcement, no event spam).
+
+## Tasks (live)
+
+- [x] T1–T9: Phase 1–4 shipped (coordination layer, dashboard, tunnel, auth wall).
+- [x] T10: Phase 5 v1 — isometric floor.
+- [ ] T11: Phase 5 v2 — walk-to-file animation, sprite art, audio cues.
+- [ ] T12: Cross-team handshake with `BP-lead` (Blip.Company office) for shared dashboard / 2-team architecture.
+- [ ] T13: Per-worker sub-pages on the dashboard (click card → drill-down).
+
+## Open questions for Sebastián
+
+- Whether `vercel-skills-qc` outputs should be office-reviewed before merging into `.claude/skills/` (default: yes).
+- Whether to merge `WORKERS/**` to main so all worktrees see the briefs (currently lives on the office branch only).

--- a/WORKERS/open-slot-1.md
+++ b/WORKERS/open-slot-1.md
@@ -1,0 +1,36 @@
+# open-slot-1 — Hot-spare worker (reserve)
+
+**Worktree**: (assigned when activated)
+**Chat label**: `QC. Open slot 1`
+**Role**: `reserve` — empty slot, no scope yet.
+
+## What this is
+
+A pre-allocated chat that Sebastián can activate when a new worker is needed. Living infrastructure (lives in the dashboard, has a desk in the isometric office) but no real responsibilities until repurposed.
+
+## Critical rules
+
+- **Hooks no-op.** Same as `notes` — no lock enforcement, no event broadcasting.
+- **No tasks, no ownership.** This chat does not edit code, run scripts, or coordinate with anyone.
+- **No peer messages.** Other workers should NOT message `open-slot-1`. If a need arises, escalate to `office`.
+
+## How to activate this slot
+
+When Sebastián wants to spin up a new worker (e.g. "we need a `mx-charts` worker for Mexico"):
+
+1. Sebastián renames the chat from `QC. Open slot 1` to `QC. <NewName>`.
+2. Discovery picks up the new title within ~10s (`discover-agents.py` runs every cycle).
+3. `office` writes a `WORKERS/<new-name>.md` brief based on Sebastián's intent.
+4. `office` updates `agents.json` with `role: worker`, `scope`, `owns_files`.
+5. Hooks start enforcing locks for the new worker on its next session.
+
+## How office renders this on the dashboard
+
+- Card shows in a "reserve" cluster (slate color), faded.
+- Counts as 0 in the "active workers" header tally.
+- Lock count always 0.
+- Last-seen / state still tracked (so we can see if Sebastián opens the chat) but doesn't trigger event-log entries.
+
+## When to add a second open slot
+
+If `open-slot-1` is chronically activated (every new worker uses it), Sebastián can create `QC. Open slot 2` and beyond. The dashboard will show all reserves automatically.

--- a/WORKERS/platform.md
+++ b/WORKERS/platform.md
@@ -1,0 +1,62 @@
+# platform — Cross-cutting deploy & infra
+
+**Worktree**: (assigned by Sebastián)
+**Chat label**: `QC. Platform` (was: `QC. API – Vercel – GitHub – Streamlit – Railay`)
+
+## Role
+
+Own the deploy pipeline and infra glue across QC's four platforms:
+
+- **Vercel** — frontend deploys (`us.qc.com`, `world.qc.com`, future country pages, `office.qc.com`).
+- **Railway** — backend / Streamlit hosting (the legacy `quartercharts.com`, future API services).
+- **GitHub Actions** — CI workflows (lint, test, deploy gates, secret rotation).
+- **Streamlit** — the legacy product still running at `quartercharts.com`. Keep it green until cutover.
+
+Owns the deploy *plumbing*, not the product code. The line: if a file affects how/where something runs, it's platform's. If a file IS the thing running, it's the relevant product worker's.
+
+## Owns
+
+- `.github/workflows/**` (all CI workflows)
+- `vercel.json` (root + per-app)
+- `railway.json`
+- `Dockerfile`, `Procfile`
+- `.streamlit/**` (Streamlit config)
+- `requirements.txt` / `pyproject.toml` / `package.json` *at the repo root* (per-app manifests stay with that app's worker)
+- Deploy scripts in `scripts/deploy/**`
+- Secrets layout in Vercel + Railway (which env vars exist where)
+- `start.sh`, `run.command`
+
+## Out of scope (do NOT touch)
+
+- Product code (`app.py`, `us-app/**`, `world-app/**`, `currency/**`, etc.).
+- Application configs that live next to the app code (e.g. `next.config.ts` for `us-app/`).
+- Cloudflare Tunnel / Access for the office dashboard — that's `office`'s.
+
+## Cross-worker coordination
+
+- `Q to=us-charts` — when changing `vercel.json` for the us-app project.
+- `Q to=globe` — same, for world-app.
+- `Q to=currency` — when deciding where the FX service deploys.
+- `Q to=office` — for any cross-cutting choice that affects the office dashboard.
+
+## Critical state
+
+- **Live legacy Streamlit**: `quartercharts.com` on Railway. Don't break.
+- **us.quartercharts.com**: Next.js on Vercel team `quartercharts-com`, project `quartercharts-com-web`.
+- **api.quartercharts.com**: placeholder on Railway, not yet built.
+- **office.quartercharts.com**: Vercel project `qc-office-dashboard` — DON'T deploy here, it's office's.
+- **DNS**: Cloudflare zone `quartercharts.com`. Wildcard CNAME `* → cname.vercel-dns.com`. Specific records override (e.g. `office-api → tunnel`).
+
+## Tasks (suggested initial)
+
+- [ ] T1: Inventory all current deploys → `docs/platform/deploy-map.md`.
+- [ ] T2: Document the secret layout: which env vars live in Vercel team-scope, project-scope, and Railway. Where each is read.
+- [ ] T3: Add a status badge per service to a `STATUS.md` (build status, last deploy, etc.).
+- [ ] T4: Vercel Pro Trial expires in ~11 days — coordinate with Sebastián on next plan.
+- [ ] T5: GitHub Actions: lint + test on PR for every product worker's repo.
+
+## Open questions
+
+- Mono-repo (everything in `miteproyects`) or split repos per app?
+- Where does the Vercel `quartercharts-global` project (showing `br.qc.com`, `ar.qc.com`) fit — yours, globe's, or business-model's?
+- Railway account migration to `info@quartercharts.com` (per memory note) — still open.

--- a/WORKERS/super-companias.md
+++ b/WORKERS/super-companias.md
@@ -1,0 +1,38 @@
+# super-companias — Ecuador SuperCompañías data extractor
+
+**Worktree**: `.claude/worktrees/crazy-kilby-d4c673`
+**Branch**: `claude/crazy-kilby-d4c673`
+**Chat label**: `1. Super Compañías`
+
+## Role
+
+Reverse-engineer `tfcsmart.com` to understand how it pulls Ecuadorian financial-statement data from the SuperCompañías. Build a Python extractor that pulls income / balance / cashflow / key-metrics for the top-10 EC companies by total assets. This feeds a future `ec.quartercharts.com` country page.
+
+## Owns
+
+- `ecuador/**` (all extractor code)
+- `docs/ecuador/**` (research notes, scraped XBRL samples)
+- `tests/ecuador/**`
+
+## Out of scope
+
+- US data sources — those live in `data_fetcher.py` (currency / streamlit will keep using SEC/FMP/Finnhub).
+- `app.py` — the legacy Streamlit product.
+- DNS / Vercel — different workers.
+
+## Notable
+
+This worker has the **only enlarged `CLAUDE.md`** (57K bytes vs 30K baseline). It contains worker-specific research notes that haven't been consolidated yet. **Don't flatten it** without reading first.
+
+## Tasks
+
+- [ ] T1: Document tfcsmart.com's data flow (network requests, auth, endpoints) — research output goes to `docs/ecuador/tfcsmart-flow.md`.
+- [ ] T2: Identify the SuperCompañías public endpoint(s) tfcsmart hits.
+- [ ] T3: Pick top-10 EC companies by assets (manual list, validate against SuperCompañías 2024 ranking).
+- [ ] T4: Build extractor → JSON-per-company in `ecuador/data/`.
+- [ ] T5: Coordinate with `business-model` for the `ec.qc.com` page-design brief.
+
+## Open questions
+
+- Which SuperCompañías portal version? (Old `supercias.gob.ec`, new `appscvs.supercias.gob.ec`, or the API?)
+- Spanish-language data — translate field names to EN, or keep ES?

--- a/WORKERS/us-charts.md
+++ b/WORKERS/us-charts.md
@@ -1,0 +1,39 @@
+# us-charts — Next.js frontend (us.quartercharts.com)
+
+**Worktree**: `.claude/worktrees/kind-haslett-2451e3`
+**Branch**: `claude/kind-haslett-2451e3`
+**Chat label**: `1. US Charts`
+
+## Role
+
+Phase 1 frontend for `usa.quartercharts.com` pro-pro: Next.js 15 app router, Tailwind v4, shadcn/ui, TypeScript strict. Deployed on Vercel at `us.quartercharts.com` (the canonical US host per memory note).
+
+## Owns
+
+- `us-app/**`
+- `vercel.json` (frontend deploy config)
+- Frontend-only `tailwind.config.*`, `next.config.*`, `tsconfig.json` if scaffolded under `us-app/`
+
+## Out of scope (do NOT touch)
+
+- `api/**` — currency owns the backend.
+- The Streamlit `app.py` — legacy product.
+- `world-app/**` — globe + searching-tool live there.
+- DNS — dns owns it.
+
+## Reassignment note
+
+Originally Currency and US Charts had the same brief ("scaffold FastAPI + Next.js"). Reassigned 2026-04-28: **us-charts = frontend only**. The FastAPI work is currency's lane.
+
+## Tasks
+
+- [ ] T1: Scaffold Next.js 15 + Tailwind v4 + shadcn + TS strict in `us-app/`.
+- [ ] T2: Deploy to Vercel (private project, `info@quartercharts.com` login).
+- [ ] T3: Stub home page (just the QC logo + a "coming soon" — logo worker will install the actual logo).
+- [ ] T4: Wire `NEXT_PUBLIC_API_URL` env to `https://api.quartercharts.com`.
+- [ ] T5: Coordinate with `logo` (Q event) when ready to receive the SVG header asset.
+- [ ] T6: Coordinate with `searching-tool` for the home-page search widget.
+
+## Open questions
+
+- Same as currency: is this a private repo separate from `miteproyects`, or a folder inside it?

--- a/WORKERS/us-sankey.md
+++ b/WORKERS/us-sankey.md
@@ -1,0 +1,46 @@
+# us-sankey — Sankey income-statement flow chart
+
+**Worktree**: (assigned per active session)
+**Chat label**: `QC. US Sankey`
+
+## Role
+
+Own the Sankey diagram that visualizes a US company's income-statement flow (revenue → costs → operating income → tax → net income). This is QC's signature chart and a key visual differentiator. Owns the rendering pipeline + the data shaping that turns raw income-statement rows into Sankey nodes/edges.
+
+Lives inside the `us-charts` Next.js app but has its own focused scope so it doesn't get squeezed by general layout work.
+
+## Owns
+
+- `us-app/components/Sankey*` (SankeyChart.tsx, SankeyNode.tsx, SankeyTooltip.tsx, etc.)
+- `lib/sankey/**` (data transforms, node/edge builders, layout algorithms)
+- `lib/sankey/colors.ts` (color palette — green for revenue, red for costs, etc.)
+- Tests for the above
+- Sankey-specific docs: `docs/sankey/spec.md`
+
+## Out of scope (do NOT touch)
+
+- General page layout in us-charts.
+- Other chart types (bar, line, area) → us-charts.
+- Source data fetching → comes from the legacy `data_fetcher.py` (Streamlit) or the future API (`platform` + `currency`).
+- Globe / world.qc.com → `globe`.
+
+## Cross-worker coordination
+
+- `Q to=us-charts` — when integrating into a new page or changing shared chart wrapper.
+- `Q to=currency` — FX conversion of income-statement values.
+- `Q to=business-model` — which Sankey features go behind the paywall (free tier may show only top-level flow; paid shows segment breakdowns).
+
+## Tasks (suggested initial)
+
+- [ ] T1: Pick the rendering library — `d3-sankey` (battle-tested, ugly out of the box), `react-flow` with sankey layout, custom SVG. Document choice in `docs/sankey/spec.md`.
+- [ ] T2: Spec the data shape: nodes (Revenue, COGS, R&D, SG&A, Op Income, Tax, Net Income, Other) + edges (with values).
+- [ ] T3: First implementation for AAPL using mock data.
+- [ ] T4: Wire to real income-statement data once `currency` + `platform` data path is ready.
+- [ ] T5: Add hover tooltips with breakdowns.
+- [ ] T6: Sankey for segments (segment revenue → segment operating income) — paid-tier feature.
+
+## Open questions
+
+- How many flow levels to show on free vs paid tier?
+- Negative values handling (e.g. when operating income is negative) — visual convention?
+- Time-series animation: can the Sankey morph from Q4 to Q1? Hard but cool. Defer.

--- a/WORKERS/vercel-skills-qc.md
+++ b/WORKERS/vercel-skills-qc.md
@@ -1,0 +1,60 @@
+# vercel-skills-qc — Skill scout
+
+**Worktree**: (assigned per active session)
+**Chat label**: `QC. Vercel Skills (QC)`
+
+## Role
+
+Survey the Vercel marketplace + the broader agent-skill ecosystem to find skills that can help the other QC workers. **Output is research and Markdown evaluations**, not product code. When a skill looks promising, propose a `.claude/skills/<name>/` config; `office` reviews before merging.
+
+This is the QC office's equivalent of a "tools-and-libraries scout" — it doesn't ship product, it ships force-multipliers for the other workers.
+
+## Owns
+
+- `docs/skills-survey/**` — Markdown briefs, one per evaluated skill
+- `.claude/skills/**` — proposed skill configs (PRs only; office reviews before merge)
+- `docs/skills-survey/index.md` — the running catalog of evaluated skills with status (`reviewing` / `proposed` / `merged` / `rejected`)
+
+## Out of scope (do NOT touch)
+
+- Product code. Skills are tooling, not product.
+- Hooks at `~/.qc-office/hooks/` → `office` owns.
+- Vercel project deploy plumbing → `platform` owns.
+
+## What "Vercel Skills" means here
+
+Vercel's marketplace (`vercel.com/marketplace`) lists integrations + extensions. There's also the broader Claude / agent-skill ecosystem (`.claude/skills/*` bundles, ClawHub at `clawhub.com`, Anthropic's bundled skills, etc.). This worker surveys all of them.
+
+Periodically: pull the Vercel docs at https://vercel.com/docs to see new skill/integration types, plus check ClawHub + Anthropic's official skills list. Read the Vercel Skills MD if Sebastián drops one in.
+
+## Workflow
+
+1. Find a skill that *might* help QC.
+2. Write a brief in `docs/skills-survey/<skill-name>.md` covering:
+   - What it does
+   - Which QC worker(s) it could help (`us-charts`, `globe`, `platform`, etc.)
+   - Cost (free / freemium / paid)
+   - License / privacy concerns
+   - Risk: lock-in, deprecation, vendor stability
+   - Recommendation: `evaluate / propose / skip`
+3. If recommendation == `propose`: write the `.claude/skills/<name>/SKILL.md` and emit `Q to=office` asking for review.
+4. Office reviews. If approved → merge. If rejected → archive the brief with the reason.
+5. If approved → notify the relevant worker(s) via `Q to=<worker>` so they know the skill is available.
+
+## Cross-worker coordination
+
+- `Q to=office` — every proposal needs review before merge.
+- `Q to=<worker>` — when a skill specifically helps that worker, brief them after merge.
+
+## Tasks (suggested initial)
+
+- [ ] T1: Inventory all currently bundled skills in `~/.claude/skills/` and `/usr/local/lib/node_modules/openclaw/skills/` → `docs/skills-survey/inventory-2026-04-28.md`.
+- [ ] T2: Browse the Vercel marketplace for QC-relevant integrations (analytics, error monitoring, feature flags, A/B testing, edge config).
+- [ ] T3: Check ClawHub for community-published skills relevant to financial-data / charting / scraping.
+- [ ] T4: Watch Anthropic's skill releases — when a new official skill drops, evaluate it.
+
+## Open questions
+
+- Should skills be reviewed by office *and* the affected worker, or just office?
+- Privacy: any skill that sends data to a third party needs `legal` review too. Add `legal` to the review chain when applicable.
+- How aggressive: propose skills weekly, monthly, or only when a real need surfaces?


### PR DESCRIPTION
Worker brief / agents.json / OFFICE.md refresh from the office branch.

## Changes

- Delete stale: `WORKERS/dns.md`, `logo.md`, `searching-tool.md` (chats no longer in active set)
- Rewrite: `office.md`, `business-model.md`, `currency.md`, `globe.md`, `super-companias.md`, `us-charts.md` (scopes refreshed for QC.* naming + 12-worker roster)
- Create: `legal.md`, `notes.md`, `open-slot-1.md`, `platform.md`, `us-sankey.md`, `vercel-skills-qc.md`
- `OFFICE.md` — drop stale "9-worker" references; agents.json is now the source of truth; new "Roles in agents.json" legend (orchestrator/worker/scratch/reserve)
- New role types in hooks: `scratch` (notes — Sebastián's pad) and `reserve` (open-slot-1) → both no-op
- Orchestrator's `MAX_LOCKS_PER_AGENT` bumped from 5 to 25

## Why now

Other worktrees can't see the new briefs until this lands on main. Sebastián's worker chats reference `WORKERS/<me>.md` on session start — without this merge they see "NOT YET WRITTEN".

## Risk

Branch only adds files + edits the spec. No production code touched. Hooks at `~/.qc-office/hooks/` already updated out-of-band (live in current sessions).