### PR TITLE
chore(repo): add gitleaks pre-commit + CI hook (track pre-commit-harden)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,20 @@
+# CI-side Gitleaks scan — fallback when the local pre-commit hook isn't
+# installed. Runs on every push and PR. Required to keep PRs green.
+name: gitleaks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Pre-commit hooks for QC repos — Gitleaks scans every commit for secrets
+# BEFORE they leave the dev machine. Pairs with the CI-side gitleaks job.
+#
+# Install once per clone:
+#   pip install pre-commit && pre-commit install
+#
+# Hook version is pinned to v8.30.1 to match the version used in the
+# 2026-05-14 GIT-AUDIT scan that established this baseline.
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## Summary

Adds Gitleaks pre-commit hook (+ CI workflow where missing) per Track GIT-PRE-COMMIT-HARDEN (2026-05-14 follow-on to GIT-AUDIT). Catches secrets BEFORE they're committed locally; CI fallback catches them at PR time if the local hook isn't installed.

Pinned to gitleaks **v8.30.1** to match the audit baseline.

Install locally: `pip install pre-commit && pre-commit install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)